### PR TITLE
remove restriction of 28 axes on a joystick

### DIFF
--- a/unix/graphics.cpp
+++ b/unix/graphics.cpp
@@ -133,27 +133,16 @@ void S9xInitDisplay (int height)
 
 	bcm_host_init();
 
-    //We handle up to four joysticks
-    if(SDL_NumJoysticks())
+    // We only handle up to two joysticks
+    int numJoySticks = SDL_NumJoysticks();
+    if (numJoySticks)
     {
+        int e = numJoySticks > 2 ? 2 : numJoySticks;
         int i;
         SDL_JoystickEventState(SDL_ENABLE);
 
-        for(i=0;i<SDL_NumJoysticks();i++) {
+        for(i=0;i<e;i++) {
             joy[i]=SDL_JoystickOpen(i);
-
-            //Check for valid joystick, some keyboards
-            //aren't SDL compatible
-            if(joy[i])
-            {
-                if (SDL_JoystickNumAxes(joy[i]) > 28)
-                {
-                    SDL_JoystickClose(joy[i]);
-                    joy[i]=0;
-                    printf("Error detected invalid joystick/keyboard\n");
-                }
-            }
-			if(i==1) break;		//Only need two joysticks
         }
     }
 


### PR DESCRIPTION
When I dug into why my PS3 controller wasn't connecting it seems it was failing here because it had 29 axes. I haven't been able to dig too much but I don't see any need for this restriction since you remap the axe into another container safely.